### PR TITLE
Prefer single quotes for string literals

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -184,7 +184,7 @@ Ruby
 * Prefer `inject` over `reduce`.
 * Prefer `map` over `collect`.
 * Prefer `select` over `find_all`.
-* Prefer double quotes for strings.
+* Prefer single quotes for strings.
 * Prefer `&&` and `||` over `and` and `or`.
 * Prefer `!` over `not`.
 * Prefer `&:method_name` to `{ |item| item.method_name }` for simple method

--- a/style/README.md
+++ b/style/README.md
@@ -184,7 +184,6 @@ Ruby
 * Prefer `inject` over `reduce`.
 * Prefer `map` over `collect`.
 * Prefer `select` over `find_all`.
-* Prefer single quotes for strings.
 * Prefer `&&` and `||` over `and` and `or`.
 * Prefer `!` over `not`.
 * Prefer `&:method_name` to `{ |item| item.method_name }` for simple method

--- a/style/rubocop.yml
+++ b/style/rubocop.yml
@@ -188,7 +188,7 @@ SpecialGlobalVars:
   Enabled: false
 
 StringLiterals:
-  EnforcedStyle: single_quotes
+  Enabled: false
 
 VariableInterpolation:
   Enabled: false

--- a/style/rubocop.yml
+++ b/style/rubocop.yml
@@ -188,7 +188,7 @@ SpecialGlobalVars:
   Enabled: false
 
 StringLiterals:
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
 
 VariableInterpolation:
   Enabled: false


### PR DESCRIPTION
Defering to the author of rubocop and what I think(?!) is consensus within the team - https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
